### PR TITLE
Fix PEKA input mismatch by joining peaks and crosslinks on metadata

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -543,9 +543,11 @@ workflow CLIPSEQ {
         /*
         * MODULE: Run peka on genome-level crosslinks
         */
+        ch_peka_input = CLIPPY_GENOME.out.peaks
+            .join(ch_genome_crosslink_bed, by: 0)
         PEKA (
-            CLIPPY_GENOME.out.peaks,
-            ch_genome_crosslink_bed,
+            ch_peka_input.map { meta, peaks, crosslinks -> [meta, peaks] },
+            ch_peka_input.map { meta, peaks, crosslinks -> [meta, crosslinks] },
             ch_fasta.collect{ it[1] },
             ch_fasta_fai.collect{ it[1] },
             ch_regions_resolved_gtf.collect{ it[1] }


### PR DESCRIPTION
This PR addresses [Issue #33](https://github.com/goodwright/clipseq/issues/33), where PEKA runs are using unmatched peak and crosslink files across samples.

The problem was caused by CLIPPY_GENOME.out.peaks and ch_genome_crosslink_bed being passed separately to the PEKA module without matching on sample metadata.

This fix joins the two channels by metadata using .join(..., by: 0) and maps them into the PEKA process, ensuring proper sample pairing.
